### PR TITLE
[ci skip] do not test on jruby-18mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ rvm:
   - "2.0.0"
   - "2.1.5"
   - "2.2.0"
-  - jruby-18mode # JRuby in 1.8 mode
   - jruby-19mode # JRuby in 1.9 mode
   - rbx


### PR DESCRIPTION
Since it requires ruby >= 1.9.3, I don't think we need to test jruby-18mode.